### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.0
+ * Update to imgui 0.6
+
 ## 0.6.0
  * Update to imgui 0.5
 

--- a/imgui-inspect-demo/Cargo.toml
+++ b/imgui-inspect-demo/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2018"
 
 [dependencies]
 
-skulpin = { version = "0.10", default-features = false, features = ["skia_complete", "skulpin_winit"] }
-skulpin-plugin-imgui = "0.6"
+skulpin = { version = "0.11.1", default-features = false, features = ["skia_complete", "skulpin_winit", "winit-23"] }
+skulpin-plugin-imgui = "0.7"
 
 log = "0.4"
 env_logger = "0.6"
 
-imgui = "0.5"
-imgui-winit-support = "0.5"
+imgui = "0.6"
+imgui-winit-support = "0.6"
 
 imgui-inspect = { path = "../imgui-inspect" }
 imgui-inspect-derive = { path = "../imgui-inspect-derive" }

--- a/imgui-inspect-derive/Cargo.toml
+++ b/imgui-inspect-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-inspect-derive"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Philip Degarmo <aclysma@gmail.com>"]
 edition = "2018"
 description = "Traits and default implementations for inspecting values with imgui."

--- a/imgui-inspect/Cargo.toml
+++ b/imgui-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-inspect"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Philip Degarmo <aclysma@gmail.com>"]
 edition = "2018"
 description = "Traits and default implementations for inspecting values with imgui."
@@ -16,5 +16,5 @@ travis-ci = { repository = "aclysma/imgui-inspect", branch = "master" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-imgui-inspect-derive = { version = "0.6", path = "../imgui-inspect-derive" }
-imgui = "0.5"
+imgui-inspect-derive = { version = "0.7", path = "../imgui-inspect-derive" }
+imgui = "0.6"


### PR DESCRIPTION
Small PR bumping `imgui-inspect` and `imgui-inspect-derive` to 0.7.0

- Bumps `imgui` to 0.6.0
- Updates demo to `imgui` 0.6.0 and  `winit` 0.23.0
